### PR TITLE
Fixed win32 failing tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,10 @@ module.exports = function (cwd, opts) {
         var ps = [ x, y ].filter(function (p) {
             return p && typeof p === 'string'
         });
-        return path.normalize(ps.join(isWindows ? '\\' : '/'));
+        var res = path.normalize(ps.join(isWindows ? '\\' : '/'));
+        if (isWindows && /^[a-zA-Z]\:\.$/.test(res))
+            return res.replace(".", "");
+        return res;
     };
     
     var res = path.normalize(cwd)
@@ -27,7 +30,7 @@ module.exports = function (cwd, opts) {
     if (res[0] === res[1]) return [ res[0] ];
     if (isWindows && /^\\/.test(cwd)) {
         return res.slice(0,-1).map(function (d) {
-            return d.replace(/^\./, '');
+            return "\\" + d;
         });
     }
     return res;


### PR DESCRIPTION
With the current version on Windows 7, all 3 win32 tests were failing. Not sure if this is the cleanest solution, but it does make the tests green.